### PR TITLE
Fixed pluginfile

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -58,7 +58,7 @@ function auth_casattras_pluginfile($course, $cm, $context, $filearea, $args, $fo
     // Retrieve the file from the Files API.
     $itemid = 0;
     $fs = get_file_storage();
-    $file = $fs->get_file($context->id, 'auth_cas', $filearea, $itemid, $filepath, $filename);
+    $file = $fs->get_file($context->id, 'auth_casattras', $filearea, $itemid, $filepath, $filename);
     if (!$file) {
         return false; // The file does not exist.
     }


### PR DESCRIPTION
Due to a wrong context in lib.php (pluginfile), probably as a result of copy-paste or plugin rename, the authentication method logo did always return a file not found error. That is most likely the cause for issue #30 which I could reproduce on my local setup (Moodle Version 3.9). I propose to change that context to the plugin name to achieve the expected behavior.